### PR TITLE
Fix setup instructions and script execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ chmod +x setup.sh
 
 Step 3: Run the script
 `
-./setup_mlops.sh
+./setup.sh
 `
 
 While running the script:

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e
 #
 # Yq is used to read the values from the configuration file. 
@@ -86,10 +87,9 @@ mc alias set myminio http://localhost:9000 minio minio123
 
 echo "📌 Buckets aanmaken op MinIO..."
 
-for BUCKET in $BUCKETS
-do
+for BUCKET in $BUCKETS; do
     echo "🪣 Creating bucket: $BUCKET"
-    mc mb myminio/$BUCKET || echo "⚠️ Bucket $BUCKET already exists, skipping..."
+    mc mb "myminio/$BUCKET" || echo "⚠️ Bucket $BUCKET already exists, skipping..."
 done
 
 


### PR DESCRIPTION
## Summary
- fix typo in README step 3 for running the setup script
- add a bash shebang to the setup script
- quote bucket path when creating buckets with `mc`

## Testing
- `bash -n setup.sh`
- `shellcheck setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d96c4305483238b2824cc043da54e